### PR TITLE
feat: Support loading 3D models from local file system (Absolute Paths & file://)

### DIFF
--- a/lib/src/core/modules/model_viewer/model_viewer_mobile.dart
+++ b/lib/src/core/modules/model_viewer/model_viewer_mobile.dart
@@ -159,8 +159,9 @@ class ModelViewerState extends State<ModelViewer> {
           if (url.isAbsolute && !url.isScheme('file')) {
             await response.redirect(url);
           } else {
-            final data = await (url.isScheme('file')
-                ? _readFile(url.path)
+            final bool isFile = url.isScheme('file') || p.isAbsolute(url.path);
+            final data = await (isFile
+                ? _readFile(url.isScheme('file') ? url.toFilePath() : url.path)
                 : _readAsset(url.path));
             response
               ..statusCode = HttpStatus.ok
@@ -184,6 +185,24 @@ class ModelViewerState extends State<ModelViewer> {
             await response.redirect(request.uri);
           } else if (request.uri.hasAbsolutePath) {
             // Some gltf models need other resources from the origin
+            if (url.isScheme('file') || p.isAbsolute(url.path)) {
+              final String parentDir = p.dirname(
+                  url.isScheme('file') ? url.toFilePath() : url.path);
+              final String filePath = p.join(
+                  parentDir, request.uri.path.replaceFirst('/', ''));
+              final file = File(filePath);
+              if (await file.exists()) {
+                final data = await file.readAsBytes();
+                response
+                  ..statusCode = HttpStatus.ok
+                  ..headers.add('Content-Type', 'application/octet-stream')
+                  ..headers.add('Content-Length', data.lengthInBytes.toString())
+                  ..headers.add('Access-Control-Allow-Origin', '*')
+                  ..add(data);
+                await response.close();
+                break;
+              }
+            }
             final pathSegments = [...url.pathSegments]..removeLast();
             final tryDestination = p.joinAll([
               url.origin,

--- a/lib/src/core/modules/obj_viewer/obj_viewer.dart
+++ b/lib/src/core/modules/obj_viewer/obj_viewer.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/widgets.dart' hide Image;
 import 'package:flutter_3d_controller/src/core/exception/flutter_3d_controller_exception.dart';
+import 'package:path/path.dart' as p;
 import 'package:vector_math/vector_math_64.dart';
 import 'scene.dart';
 
 typedef SceneCreatedCallback = void Function(
-    Scene scene, String modelName, String? modelUrl);
+    Scene scene, String modelName, String? modelUrl,
+    {bool isAsset});
 
 class ObjViewer extends StatefulWidget {
   const ObjViewer({
@@ -59,8 +61,9 @@ class _ObjViewerState extends State<ObjViewer> {
     // prevent setState() or markNeedsBuild called during build
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final modelSrcData = _parseModelSrc(widget.src);
-      widget.onSceneCreated
-          ?.call(scene, modelSrcData[0] ?? widget.src, modelSrcData[1]);
+      widget.onSceneCreated?.call(
+          scene, modelSrcData.name ?? widget.src, modelSrcData.url,
+          isAsset: modelSrcData.isAsset);
     });
   }
 
@@ -74,8 +77,9 @@ class _ObjViewerState extends State<ObjViewer> {
       );
       WidgetsBinding.instance.addPostFrameCallback((_) {
         final modelSrcData = _parseModelSrc(widget.src);
-        widget.onSceneCreated
-            ?.call(scene, modelSrcData[0] ?? widget.src, modelSrcData[1]);
+        widget.onSceneCreated?.call(
+            scene, modelSrcData.name ?? widget.src, modelSrcData.url,
+            isAsset: modelSrcData.isAsset);
       });
     }
   }
@@ -122,23 +126,22 @@ Vector2 toVector2(Offset value) {
   return Vector2(value.dx, value.dy);
 }
 
-List<String?> _parseModelSrc(String src) {
-  List<String?> result = List.filled(2, null, growable: false);
+({String? name, String? url, bool isAsset}) _parseModelSrc(String src) {
   if (!src.toLowerCase().endsWith('.obj')) {
     throw Flutter3dControllerFormatException();
   } else if (src.startsWith('http://') || src.startsWith('https://')) {
     //model is loading from url
     String modelName = src.substring(src.lastIndexOf('/') + 1);
     String modelPath = src.substring(0, src.lastIndexOf('/') + 1);
-    result[0] = modelName;
-    result[1] = modelPath;
+    return (name: modelName, url: modelPath, isAsset: false);
+  } else if (src.startsWith('file://') || p.isAbsolute(src)) {
+    //model is loading from local file
+    return (name: src, url: null, isAsset: false);
   } else if (src.contains('assets')) {
     //model is loading from local asset
-    result[0] = src;
-    result[1] = null;
+    return (name: src, url: null, isAsset: true);
   } else {
     throw Flutter3dControllerFormatException(
         message: 'Cannot Parse the model source.');
   }
-  return result;
 }

--- a/lib/src/widgets/flutter_3d_viewer.dart
+++ b/lib/src/widgets/flutter_3d_viewer.dart
@@ -113,7 +113,7 @@ class _Flutter3DViewerState extends State<Flutter3DViewer> {
         ? ObjViewer(
             src: widget.src,
             interactive: widget.enableTouch,
-            onSceneCreated: (scene, modelName, modelUrl) {
+            onSceneCreated: (scene, modelName, modelUrl, {bool? isAsset}) {
               scene.camera.position.z = widget.cameraZ ?? 10;
               scene.camera.target.y = widget.cameraY ?? 0;
               scene.camera.target.x = widget.cameraX ?? 0;
@@ -123,6 +123,7 @@ class _Flutter3DViewerState extends State<Flutter3DViewer> {
                       widget.scale ?? 5.0),
                   fileName: modelName,
                   url: modelUrl,
+                  isAsset: isAsset ?? true,
                   onProgress: widget.onProgress,
                   onLoad: (modelAddress) {
                     widget.onLoad?.call(modelAddress);


### PR DESCRIPTION

This PR implements full support for loading 3D models (`.obj`, `.gltf`, `.glb`) directly from the device's local storage. Previously, the library was limited to loading models from remote URLs (`http/s`) or embedded Flutter Assets.

**Key Changes**

* **Local File Recognition:** Updated `_parseModelSrc` in `obj_viewer.dart` and `model_viewer_mobile.dart` to recognize absolute paths (e.g., from a file picker) and `file://` schemes.
* **OBJ Viewer Support:** Fixed logic that previously threw a `Flutter3dControllerFormatException` when attempting to load an OBJ file from a local path.
* **Relative Resource Handling:** Updated the internal local server in `model_viewer_mobile.dart`. It now correctly resolves dependent resources (like `.bin` files or textures) located in the same local directory as the main model file by checking the parent directory.
* **API Update:** Updated `onSceneCreated` and internal loading logic to explicitly track `isAsset`, ensuring the viewer knows whether to look in the app bundle or on the disk.

**Usage Example**
Users can now pass a file path directly to the viewer:

```dart
// Using a path from a file picker
String localPath = "/storage/emulated/0/Download/my_model.obj";

Flutter3DViewer(
  src: localPath, 
  // ...
)

```

**Impact**

* Resolves issues where local files were treated as invalid formats.
* Enables offline model viewing features for apps that download models or let users import them.